### PR TITLE
Raise a typed exception for 502 and 504 gateway errors

### DIFF
--- a/lib/upland_mobile_commons_rest/errors.rb
+++ b/lib/upland_mobile_commons_rest/errors.rb
@@ -146,6 +146,10 @@ module UplandMobileCommonsRest
         raise BadGatewayError
       when 504
         raise GatewayTimeoutError
+      when 500...600
+        # Just in case we get other 5xx errors, raise something for those
+        # This has not happened that we know of, but better safe than sorry!
+        raise UnknownError, response.inspect
       end
     end
   end

--- a/lib/upland_mobile_commons_rest/errors.rb
+++ b/lib/upland_mobile_commons_rest/errors.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module UplandMobileCommonsRest
+  class NetworkError < StandardError; end
+  class BadGatewayError < NetworkError; end
+  class GatewayTimeoutError < NetworkError; end
+
   class MobileCommonsError < StandardError
     attr_accessor :code, :raw_message
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -91,6 +91,15 @@ describe UplandMobileCommonsRest::Client do
       end
     end
 
+    context '503 status response' do
+      let(:response_status) { 503 }
+      let(:response_body) { '<html><head><title>503 Internal Server Error</title></head><body><center><h1>503 Internal Server Error</h1></center></body></html>' }
+
+      it 'should raise an UnknownError' do
+        expect{ subject.post_request('do_something', request_params) }.to raise_error(UplandMobileCommonsRest::UnknownError)
+      end
+    end
+
     context '504 status response' do
       let(:response_status) { 504 }
       let(:response_body) { '<html><head><title>504 Gateway Time-out</title></head><body><center><h1>504 Gateway Time-out</h1></center></body></html>' }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -17,4 +17,87 @@ describe UplandMobileCommonsRest::Client do
       expect(campaigns.client).to eq(subject)
     end
   end
+
+  describe 'error handling' do
+    let(:request_params) { {example: 'data'} }
+
+    subject { UplandMobileCommonsRest::Client.new(username: 'foo', password: 'bar') }
+
+    before :each do
+      stub_request(:post, 'https://secure.mcommons.com/api/do_something')
+        .to_return(status: response_status, body: response_body)
+    end
+
+    shared_examples_for 'error code parsing' do
+      UplandMobileCommonsRest::TypedErrorMiddleware::POSSIBLE_ERRORS.each do |code, ex_type|
+        context "response body with success=false and error code #{code}" do
+          let(:response_body) do
+            <<~XML
+            <response success="false">
+              <error id="#{code}" message="This is not correct!"/>
+            </response>
+            XML
+          end
+
+          it "should raise #{ex_type}" do
+            expect{ subject.post_request('do_something', request_params) }.to raise_error(ex_type)
+          end
+        end
+      end
+    end
+
+    context '200 status response' do
+      let(:response_status) { 200 }
+
+      context 'no response body' do
+        let(:response_body) { nil }
+
+        it 'should raise an UnknownError' do
+          expect{ subject.post_request('do_something', request_params) }.to raise_error(UplandMobileCommonsRest::UnknownError)
+        end
+      end
+
+      context 'response body without <response> tag' do
+        let(:response_body) { '<body>Well, this is unexpected!</body>' }
+
+        it 'should raise an UnknownError' do
+          expect{ subject.post_request('do_something', request_params) }.to raise_error(UplandMobileCommonsRest::UnknownError)
+        end
+      end
+
+      context 'response body with success=true' do
+        let(:response_body) { '<response success="true">hurray!</response>' }
+
+        it 'should not raise' do
+          expect{ subject.post_request('do_something', request_params) }.not_to raise_error
+        end
+      end
+
+      include_examples 'error code parsing'
+    end
+
+    context '400 status response' do
+      let(:response_status) { 400 }
+
+      include_examples 'error code parsing'
+    end
+
+    context '502 status response' do
+      let(:response_status) { 502 }
+      let(:response_body) { '<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center></body></html>' }
+
+      it 'should raise an BadGatewayError' do
+        expect{ subject.post_request('do_something', request_params) }.to raise_error(UplandMobileCommonsRest::BadGatewayError)
+      end
+    end
+
+    context '504 status response' do
+      let(:response_status) { 504 }
+      let(:response_body) { '<html><head><title>504 Gateway Time-out</title></head><body><center><h1>504 Gateway Time-out</h1></center></body></html>' }
+
+      it 'should raise an GatewayTimeoutError' do
+        expect{ subject.post_request('do_something', request_params) }.to raise_error(UplandMobileCommonsRest::GatewayTimeoutError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This updates our error handling so that when we get a "502 Bad Gateway" or "504 Gateway Time-out" response from the Mobile Commons API, we raise a typed exception instead of trying to parse the response body.

This should make exceptions like https://rollbar.com/ChangeSproutInc./agra/items/3916 and https://rollbar.com/ChangeSproutInc./agra/items/3921/ less noisy and easier to understand.