### PR TITLE
Raise a typed exception when API calls return a Heavy Load message

### DIFF
--- a/lib/upland_mobile_commons_rest/errors.rb
+++ b/lib/upland_mobile_commons_rest/errors.rb
@@ -33,6 +33,12 @@ module UplandMobileCommonsRest
       case status_code
       when 502
         raise BadGatewayError.new(response)
+      when 503
+        if /This website is under heavy load/.match?(response.body)
+          raise HeavyLoadError, response.body
+        else
+          raise UnknownError, response.body
+        end
       when 504
         raise GatewayTimeoutError.new(response)
       when 500...600
@@ -46,6 +52,8 @@ module UplandMobileCommonsRest
   class MobileCommonsError < StandardError
     attr_accessor :code, :raw_message
   end
+
+  class HeavyLoadError < MobileCommonsError; end
 
   class UnknownError < MobileCommonsError; end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -107,6 +107,18 @@ describe UplandMobileCommonsRest::Client do
           expect(error.to_s).to include(response_body)
         end
       end
+
+      context 'with Heavy Load message' do
+        let(:response_body) { "<h2>This website is under heavy load (queue full)</h2><p>We're sorry, too many people are accessing this website at the same time. We're working on this problem. Please try again later.</p>" }
+
+        it 'should raise a HeavyLoadError' do
+          expect do
+            subject.post_request('do_something', request_params)
+          end.to raise_error(UplandMobileCommonsRest::HeavyLoadError) do |error|
+            expect(error.to_s).to include(response_body)
+          end
+        end
+      end
     end
 
     context '504 status response' do


### PR DESCRIPTION
Updates the error parsing middleware so that if our call to Mobile Commons returns a "This website is under heavy load" message, we raise a typed exception (`UplandMobileCommonsRest::HeavyLoadError`) rather than a more generic `UplandMobileCommonsRest::UnknownError`.

This should make it easier for users of this client to handle the Heavy Load error appropriately.